### PR TITLE
Add additional device features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ A Java wrapper for the [SDRplay API v3](https://www.sdrplay.com/) using [JNR-FFI
   * The Java-like wrapper will only expose limited functionality at first to the extent that I'm able to test it.
 * I only have an RSP1, so it's possible some of the features that work for me may not work on other hardware.
 * The JNR wrapper is largely complete except for some model-specifc features.  The friendly Java API is less complete and only contains a few core controls, but should be sufficient for basic use.
+* http://jnrproject.org/jnr-ffi/apidocs/index.html NDH: found these which may or may not be useful
+
+### Modifications v0.7.0 Neil Harvey 2021
+* Updated structs to cover all device parameters for all API supported SDRplay devices
+* Provided methods for updating the following parameters:
+ * Automatic Gain Control (AGC)
+ * Decimation
+ * DC Offset
+ * Broadcast FM Notch (RSP1A only)
+ * Digital Audio Broadcast (DAB) Notch (RSP1A only)
+ * Bias-T (RSP1A only) 
 
 #### With Thanks To
 The [SerCeMan/jnr-fuse](https://github.com/SerCeMan/jnr-fuse) project for being an excellent example of working, complex JNR code.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 // Publishing Info
-version = '0.6.0'
+version = '0.7.0'
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
@@ -40,6 +40,10 @@ def pomConfig = {
             id "Sammy1Am"
             name "Sam A"
         }
+        developer {
+            id "neilharvey94044"
+            name "Neil Harvey"
+        }
     }
 
     scm {
@@ -52,7 +56,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'io.github.sammy1am'
             artifactId = 'SDRplayJava'
-            version = '0.6.0'
+            version = '0.7.0'
 
             from components.java
             artifact sourcesJar {

--- a/src/main/java/io/github/sammy1am/sdrplay/SDRplayAPI.java
+++ b/src/main/java/io/github/sammy1am/sdrplay/SDRplayAPI.java
@@ -87,8 +87,8 @@ public class SDRplayAPI {
         RSP1(1),
         RSP1A(255),
         RSP2(2),
-        RSPduo(3),
-        RSPdx(4);
+        RSPDUO(3),
+        RSPDX(4);
         
         private final int val;
         

--- a/src/main/java/io/github/sammy1am/sdrplay/SDRplayAPI.java
+++ b/src/main/java/io/github/sammy1am/sdrplay/SDRplayAPI.java
@@ -1,6 +1,7 @@
 package io.github.sammy1am.sdrplay;
 
 import io.github.sammy1am.sdrplay.model.RSPDuo;
+import io.github.sammy1am.sdrplay.model.RSP1A;
 import io.github.sammy1am.sdrplay.jnr.SDRplayAPIJNR;
 import io.github.sammy1am.sdrplay.jnr.SDRplayAPIJNR.ErrT;
 import java.util.ArrayList;
@@ -64,11 +65,14 @@ public class SDRplayAPI {
         
         for (int d=0;d<numDevices.intValue();d++) {
             // Create a new SDRplayDevice using the native device and add it to the list
-            switch (devices[d].hwVer.byteValue()) {
+            switch ((int) devices[d].hwVer.byteValue() & 0xFF) {
                 //TODO Add device classes for other models
                 case 3:
                     returnDevices.add(new RSPDuo(devices[d]));
                     break;
+                case 255:
+                	returnDevices.add(new RSP1A(devices[d]));
+                	break;
                 case 1:
                 default:
                     returnDevices.add(new SDRplayDevice(devices[d]));
@@ -79,7 +83,7 @@ public class SDRplayAPI {
     }
     
     public static enum HWModel {
-        UNKNOWN(-1),
+        UNKNOWN(0),
         RSP1(1),
         RSP1A(255),
         RSP2(2),

--- a/src/main/java/io/github/sammy1am/sdrplay/jnr/DeviceParamsT.java
+++ b/src/main/java/io/github/sammy1am/sdrplay/jnr/DeviceParamsT.java
@@ -7,15 +7,16 @@ import jnr.ffi.util.EnumMapper;
 /**
  * JNR file containing sdrplay_api_DeviceParamsT and sub-structures (sdrplay_api_dev.h).
  */
-public class DeviceParamsT extends Struct {
+	public class DeviceParamsT extends Struct {
     
-    public StructRef<DevParamsT> devParams = new StructRef<>(DevParamsT.class);
-    public StructRef<RxChannelParamsT> rxChannelA = new StructRef<>(RxChannelParamsT.class);
-    public StructRef<RxChannelParamsT> rxChannelB = new StructRef<>(RxChannelParamsT.class);
-    
-    public DeviceParamsT(final Runtime runtime) {
-        super(runtime);
-    }
+	    public StructRef<DevParamsT> devParams = new StructRef<>(DevParamsT.class);
+	    public StructRef<RxChannelParamsT> rxChannelA = new StructRef<>(RxChannelParamsT.class);
+	    public StructRef<RxChannelParamsT> rxChannelB = new StructRef<>(RxChannelParamsT.class);
+	    
+	    public DeviceParamsT(final Runtime runtime) {
+	        super(runtime);
+	    }
+	
     
     public static class DevParamsT extends Struct {
 
@@ -26,23 +27,92 @@ public class DeviceParamsT extends Struct {
         public Struct.Enum<TransferModeT> mode; // default: sdrplay_api_ISOCH
         public Unsigned32 samplesPerPkt;        // default: 0 (output param)
         
-// TODO
-//        Rsp1aParamsT rsp1aParams;
-//        Rsp2ParamsT rsp2Params;
-//        RspDuoParamsT rspDuoParams;
-//        RspDxParamsT rspDxParams;
+        // Device specific parameters
+        public Rsp1aParamsT rsp1aParams;
+        public Rsp2ParamsT   rsp2Params;
+        public RspDuoParamsT rspduoParams;
+        public RspDxParamsT rspdxParams;
         
         
         public DevParamsT(final Runtime runtime) {
             super(runtime);
-            // Initialize here for acess to runtime
+            // Initialize here for access to runtime
             ppm = new Double();
             fsFreq = inner(new FsFreqT(runtime));
             syncUpdate = inner(new SyncUpdateT(runtime));
             resetFlags = inner(new ResetFlagsT(runtime));
             mode = new Struct.Enum<>(TransferModeT.class);
             samplesPerPkt = new Unsigned32();
+            rsp1aParams = inner(new Rsp1aParamsT(runtime));
+            rsp2Params = inner(new Rsp2ParamsT(runtime));
+            rspduoParams = inner(new RspDuoParamsT(runtime));
+            rspdxParams = inner(new RspDxParamsT(runtime));
+            
         }
+    }
+    
+    public static class Rsp1aParamsT extends Struct {
+    	public Unsigned8 rfNotchEnable;          // default: 0
+        public Unsigned8 rfDabNotchEnable;
+        
+    	public Rsp1aParamsT(final Runtime runtime) {
+    		super(runtime);
+    		rfNotchEnable = new Unsigned8();
+    		rfDabNotchEnable = new Unsigned8();
+    	}
+    }
+    
+    public static class Rsp2ParamsT extends Struct {
+    	Unsigned8 extRefOutputEn;                // default: 0
+    	
+    	public Rsp2ParamsT(final Runtime runtime) {
+    		super(runtime);
+    		extRefOutputEn = new Unsigned8();
+    	}
+    }
+    
+    public static class RspDuoParamsT extends Struct {
+    	Signed16 extRefOutputEn;                             // default: 0
+    	
+    	public RspDuoParamsT(final Runtime runtime) {
+    		super(runtime);
+    		extRefOutputEn = new Signed16();
+    	}
+    }
+    
+    public static class RspDxParamsT extends Struct {
+    	public Unsigned8 hdrEnable;                            // default: 0
+    	public Unsigned8 biasTEnable;                          // default: 0
+    	public Struct.Enum<RspDx_AntennaSelectT> antennaSel;    // default: sdrplay_api_RspDx_ANTENNA_A
+    	public Unsigned8 rfNotchEnable;                        // default: 0
+    	public Unsigned8 rfDabNotchEnable;                     // default: 0
+    	
+    	public RspDxParamsT(final Runtime runtime) {
+    		super(runtime);
+    		hdrEnable = new Unsigned8();
+    		biasTEnable = new Unsigned8();
+    		antennaSel = new Struct.Enum<>(RspDx_AntennaSelectT.class);
+    		rfNotchEnable = new Unsigned8();
+    		rfDabNotchEnable = new Unsigned8();
+    		
+    	}
+    }
+    
+    public static enum RspDx_AntennaSelectT {
+    	RspDx_ANTENNA_A (0),
+    	RspDx_ANTENNA_B (1),
+    	RspDx_ANTENNA_C (2);
+    	
+    	private final int val;
+    	
+    	RspDx_AntennaSelectT(int val) {
+    		this.val = val;
+    	}
+
+    	public int intValue() {
+    		return val;
+    	}
+    	
     }
     
     public static enum TransferModeT {
@@ -93,17 +163,137 @@ public class DeviceParamsT extends Struct {
 
         public TunerParamsT tunerParams;
         public ControlParamsT ctrlParams;
-        
-// TODO
-//        Rsp1aTunerParamsT   rsp1aTunerParams; 
-//        Rsp2TunerParamsT    rsp2TunerParams; 
-//        RspDuoTunerParamsT  rspDuoTunerParams;    
-//        RspDxTunerParamsT   rspDxTunerParams;
-        
+        public Rsp1aTunerParamsT rsp1aTunerParams;
+        public Rsp2TunerParamsT rsp2TunerParams;
+        public RspDuoTunerParamsT rspduoTunerParams;
+        public RspDxTunerParamsT rspdxTunerParams;
+       
         public RxChannelParamsT(final Runtime runtime) {
             super(runtime);
             tunerParams = inner(new TunerParamsT(runtime));
             ctrlParams = inner(new ControlParamsT(runtime));
+            rsp1aTunerParams = inner(new Rsp1aTunerParamsT(runtime));
+            rsp2TunerParams = inner(new Rsp2TunerParamsT(runtime));
+            rspduoTunerParams = inner(new RspDuoTunerParamsT(runtime));
+            rspdxTunerParams = inner(new RspDxTunerParamsT(runtime));
         }
     }
+    
+    public static class Rsp1aTunerParamsT extends Struct{
+    	public  Unsigned8 biasTEnable;                   // default: 0
+    	
+    	public Rsp1aTunerParamsT(final Runtime runtime) {
+    		super(runtime);
+    		biasTEnable = new Unsigned8();
+    	}
+    }
+    
+    public static class Rsp2TunerParamsT extends Struct {
+    	    public Unsigned8 biasTEnable;                   		// default: 0
+    	    public Struct.Enum<Rsp2_AmPortSelectT> amPortSel;    	// default: sdrplay_api_Rsp2_AMPORT_2
+    	    public Struct.Enum<Rsp2_AntennaSelectT> antennaSel;  	// default: sdrplay_api_Rsp2_ANTENNA_A
+    	    public Unsigned8 rfNotchEnable;                 		// default: 0
+    	    
+    	    public Rsp2TunerParamsT (final Runtime runtime) {
+    	    	super(runtime);
+    	    	
+    	    	biasTEnable = new Unsigned8();
+    	    	amPortSel = new Struct.Enum<>(Rsp2_AmPortSelectT.class);
+    	    	antennaSel = new Struct.Enum<>(Rsp2_AntennaSelectT.class);
+    	    	rfNotchEnable = new Unsigned8();
+    	    	
+    	    }
+    }
+    
+    public static enum Rsp2_AmPortSelectT {
+    	 Rsp2_AMPORT_1 (1),
+    	 Rsp2_AMPORT_2 (0);
+    	
+    	 private final int val;
+    	 
+    	 Rsp2_AmPortSelectT(int val) {
+    		 this.val = val;
+    	 }
+    	 
+    	 public int intValue() {
+    		 return val;
+    	 }
+    }
+    
+    public static enum Rsp2_AntennaSelectT {
+    	Rsp2_ANTENNA_A (5),
+    	Rsp2_ANTENNA_B (6);
+   	
+   	 private final int val;
+   	 
+   	 Rsp2_AntennaSelectT(int val) {
+   		 this.val = val;
+   	 }
+   	 
+   	 public int intValue() {
+   		 return val;
+   	 }
+   }
+   
+    public static class RspDuoTunerParamsT extends Struct {
+    	  public Unsigned8 biasTEnable;                    // default: 0
+    	  public Struct.Enum<RspDuo_AmPortSelectT> tuner1AmPortSel; 	// default: sdrplay_api_RspDuo_AMPORT_2
+    	  public Unsigned8 tuner1AmNotchEnable;            // default: 0
+    	  public Unsigned8 rfNotchEnable;                  // default: 0
+    	  public Unsigned8 rfDabNotchEnable;               // default: 0
+    	  
+    	  public RspDuoTunerParamsT(final Runtime runtime) {
+    		  super(runtime);
+    		  
+    		  biasTEnable = new Unsigned8();
+    		  tuner1AmPortSel = new Struct.Enum<>(RspDuo_AmPortSelectT.class);
+    		  tuner1AmNotchEnable = new Unsigned8();
+    		  rfNotchEnable = new Unsigned8();
+    		  rfDabNotchEnable = new Unsigned8();
+    	  }
+    }
+    
+    public enum RspDuo_AmPortSelectT {
+    	RspDuo_AMPORT_1 (1),
+    	RspDuo_AMPORT_2 (0);
+    	
+    	final int val;
+    	
+    	RspDuo_AmPortSelectT(int val) {
+    		this.val = val;
+    	}
+    	
+    	public int intValue() {
+    		return val;
+    	}
+    }
+    
+    public static class RspDxTunerParamsT extends Struct {
+    	public Struct.Enum<RspDx_HdrModeBwT> hdrBw;
+    	
+    	public RspDxTunerParamsT(final Runtime runtime) {
+    		super(runtime);
+    		
+    		hdrBw = new Struct.Enum<>(RspDx_HdrModeBwT.class);
+    	}
+    }
+    
+    public enum RspDx_HdrModeBwT {
+    	RspDx_HDRMODE_BW_0_200  (0),
+    	RspDx_HDRMODE_BW_0_500  (1),
+    	RspDx_HDRMODE_BW_1_200  (2),
+    	RspDx_HDRMODE_BW_1_700  (3);
+    	
+    	final int val;
+    	
+    	RspDx_HdrModeBwT(int val) {
+    		this.val = val;
+    	}
+    	
+    	public int intValue() {
+    		return val;
+    	}
+    	
+    }
+    
 }

--- a/src/main/java/io/github/sammy1am/sdrplay/jnr/SDRplayAPIJNR.java
+++ b/src/main/java/io/github/sammy1am/sdrplay/jnr/SDRplayAPIJNR.java
@@ -119,7 +119,8 @@ public interface SDRplayAPIJNR {
         Update_RspDuo_AmPortSelect        (0x10000000),
         Update_RspDuo_Tuner1AmNotchControl(0x20000000),
         Update_RspDuo_RfNotchControl      (0x40000000),
-        Update_RspDuo_RfDabNotchControl   (0x80000000);
+        Update_RspDuo_RfDabNotchControl   (0x80000000),
+    	Update_Custom_sdrtrunk_SampleRateChange (0x00000001 & 0x00040000 & 0x00080000);
          
         private final int val;
 

--- a/src/main/java/io/github/sammy1am/sdrplay/model/RSP1A.java
+++ b/src/main/java/io/github/sammy1am/sdrplay/model/RSP1A.java
@@ -1,0 +1,67 @@
+package io.github.sammy1am.sdrplay.model;
+
+import io.github.sammy1am.sdrplay.SDRplayDevice;
+import io.github.sammy1am.sdrplay.jnr.SDRplayAPIJNR;
+import io.github.sammy1am.sdrplay.jnr.SDRplayAPIJNR.ReasonForUpdateT;
+
+/**
+ *
+ * @author Sammy1Am
+ */
+public class RSP1A extends SDRplayDevice {
+    
+	private final byte NUM_LNA_STATES_BELOW_60_MHZ = 7;
+    private final byte NUM_LNA_STATES_BELOW_1_GHZ = 10;
+    private final byte NUM_LNA_STATES_LBAND = 9;
+    
+    public RSP1A(SDRplayAPIJNR.DeviceT nativeDevice) {
+        super(nativeDevice);
+    }
+
+    @Override
+    public byte getNumLNAStates() {
+        double currentFreq = nativeParams.rxChannelA.get().tunerParams.rfFreq.rfHz.get();
+        if (currentFreq < 60_000_000) {
+        	return NUM_LNA_STATES_BELOW_60_MHZ;
+        }
+        else if (currentFreq < 1_000_000_000) {
+            return NUM_LNA_STATES_BELOW_1_GHZ;
+        } else {
+            return NUM_LNA_STATES_LBAND;
+        }
+    }
+    
+    // TODO Implement model-specific functionality.
+    @Override
+    public boolean getRfNotch() {
+    	return (nativeParams.devParams.get().rsp1aParams.rfNotchEnable.get() >= 1);
+    }
+    
+    @Override
+    public void setRfNotch(boolean rfNotch) {
+    	nativeParams.devParams.get().rsp1aParams.rfNotchEnable.set(rfNotch ? 1 : 0);
+    	if (isInitialized) doUpdate(ReasonForUpdateT.Update_Rsp1a_RfNotchControl);
+    }
+    
+    @Override
+    public boolean getDABNotch() {
+    	return (nativeParams.devParams.get().rsp1aParams.rfNotchEnable.get() >= 1);
+    }
+    
+    @Override
+    public void setDABNotch(boolean dabNotch) {
+    	nativeParams.devParams.get().rsp1aParams.rfNotchEnable.set(dabNotch ? 1 : 0);
+    	if (isInitialized) doUpdate(ReasonForUpdateT.Update_Rsp1a_RfDabNotchControl);
+    }
+    
+    @Override
+    public boolean getBiasT() {
+    	return (nativeParams.rxChannelA.get().rsp1aTunerParams.biasTEnable.get() >= 1);
+    }
+    
+    @Override
+    public void setBiasT(boolean biasT) {
+    	nativeParams.rxChannelA.get().rsp1aTunerParams.biasTEnable.set(biasT ? 1 : 0);
+    	if (isInitialized) doUpdate(ReasonForUpdateT.Update_Rsp1a_BiasTControl);
+    }
+}


### PR DESCRIPTION
I've made changes to complete the TODOs you left and add methods to support additional features in SDRplay devices, with a focus on RSP1A but enabling additional capabilities and expansion for all SDRplay devices.  The changes I've made here are dependencies to a larger set of changes I've made for sdrtrunk to do the following:

1. Sample Size and IF Bandwidth are aligned, same as done in SDRuno from SDRplay.

2. Defaults to using IF Zero for all Sample Sizes.

3. Decimation has been implemented with allowable values based upon Sample Size.

4. Automatic Gain Control (AGC) has been implemented.

5. Defaults to DC Offset calibration enabled.

6. For RSP1A the Bias-T, FM Broadcast Notch, and Digital Audio Broadcast Notch options have been implemented.

7.  For RSP1A, the number of LNA RF Gain Reduction states matches the RSP1A capabilities.

8.  Additional SDRplay device capabilities can be more easily added in future releases.

These changes should allow users to get up and running with SDRplay devices in sdrtrunk with fewer challenges.  I modeled the settings after SDRPlay's SDRuno software.

Feel free to email me directly, my email address is published on Github.